### PR TITLE
Improved reporting by adding divider between items

### DIFF
--- a/src/Elfiggo/Brobdingnagian/Report/Reporter.php
+++ b/src/Elfiggo/Brobdingnagian/Report/Reporter.php
@@ -37,7 +37,8 @@ class Reporter
             $io->writeln('--------------------------------------------------------------------------------');
             $io->writeln('|  ' . str_pad('Error Type',17) . '  |  ' . str_pad('Message', 52) . '  |');
             foreach($this->handler->messages() as $class => $messages) {
-                $io->writeln(str_pad('-- Class -- ', 22) . '|  ' . str_pad($class, 67 - strlen($class)));
+                $io->writeln('--------------------------------------------------------------------------------');
+                $io->writeln(str_pad('|  -- Class -- ', 22) . '|  ' . str_pad($class, 67 - strlen($class)));
                 foreach ($messages as $data) {
                     $io->writeln('|  ' . str_pad($data['errorType'],17) . '  |  ' . $data['message']);
                 }


### PR DESCRIPTION
From this...

```
-- Class --           |  CR\Bundle\FilePublisherBundle\DirectoryScanner\Adapter
|  Method size        |  scan() size is 11 lines long
-- Class --           |  CR\Bundle\FilePublisherBundle\DirectoryScanner\EventDispatchingDirectoryScanner
|  Method size        |  scan() size is 21 lines long
-- Class --           |  CR\Bundle\FilePublisherBundle\Event\Dispatcher
|  Too many methods   |  CR\Bundle\FilePublisherBundle\Event\Dispatcher has too many methods (6)
```

To this...

```
--------------------------------------------------------------------------------
|  -- Class --        |  CR\Bundle\FilePublisherBundle\DirectoryScanner\Adapter
|  Method size        |  scan() size is 11 lines long
--------------------------------------------------------------------------------
|  -- Class --        |  CR\Bundle\FilePublisherBundle\DirectoryScanner\EventDispatchingDirectoryScanner
|  Method size        |  scan() size is 21 lines long
--------------------------------------------------------------------------------
|  -- Class --        |  CR\Bundle\FilePublisherBundle\Event\Dispatcher
|  Too many methods   |  Crossrail\Bundle\FilePublisherBundle\Event\Dispatcher has too many methods (6)
--------------------------------------------------------------------------------
|  -- Class --        |  CR\Bundle\FilePublisherBundle\Event\Factory
|  Too many methods   |  Crossrail\Bundle\FilePublisherBundle\Event\Factory has too many methods (6)
--------------------------------------------------------------------------------
|  -- Class --        |  CR\Bundle\FilePublisherBundle\FileCataloguer\Adapter
|  Method size        |  catalogue() size is 15 lines long
--------------------------------------------------------------------------------

```
